### PR TITLE
Try to avoid multiple texture uploads for YUV video

### DIFF
--- a/pygfx/renderers/wgpu/wgsl/image.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/image.wgsl
@@ -37,7 +37,12 @@ fn vs_main(in: VertexInput) -> Varyings {
 
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
+$$ if colorspace == "yuv420p-semiplanar"
+    let _sizef = vec2<f32>(textureDimensions(t_img));
+    let sizef = vec2<f32>(_sizef.x, _sizef.y * 1.5);
+$$ else
     let sizef = vec2<f32>(textureDimensions(t_img));
+$$ endif
     let value = sample_im(varyings.texcoord.xy, sizef);
     let color = sampled_value_to_color(value);
 

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -113,6 +113,7 @@ class Texture(Resource):
             "tex-srgb",
             "physical",
             "yuv420p",
+            "yuv420p-semiplanar",
             "yuv444p",
         )
         self._colorrange = (colorrange or "limited").lower()


### PR DESCRIPTION
I believe that the sheer count of texture uploads is a cause of slowdowns especially on Linux + Nvidia.

This is my attempt at sampling the "reshaped"

YUV420p texture were a single packed texture is returned, but the u and v are downsample by 2 in both axes making it tricky to access the right data.

Still very much a WIP