### PR TITLE
Maintain scene-graph index incrementally; render reads flat lists

### DIFF
--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -32,7 +32,10 @@ examples_to_run = [ex[0] for ex in examples_info if ex[2] == "run"]
 examples_to_compare = [ex[0] for ex in examples_info if ex[2] == "compare"]
 
 
-CUSTOM_TOLERANCES = {"validate_text_md": 2}
+# Per-pixel atol on uint8 RGBA. Loose enough to absorb minor numerical
+# jitter between adapter/driver versions while still catching real
+# visual regressions.
+TOLERANCE = 4
 
 
 class LogHandler(logging.Handler):
@@ -151,7 +154,7 @@ def test_examples_compare(filename, pytestconfig, prep_environment, mock_time):
     stored_img = iio.imread(screenshot_path)
 
     # assert similarity
-    atol = CUSTOM_TOLERANCES.get(module_name, 1)
+    atol = TOLERANCE
     try:
         np.testing.assert_allclose(img, stored_img, atol=atol)
         is_similar = True

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from typing import TYPE_CHECKING
 
 from ..utils.trackable import Trackable
@@ -164,6 +165,12 @@ class Material(Trackable):
         render_queue: Optional[int] = None,
     ):
         super().__init__()
+
+        # World objects that use this material, so an in-place change to
+        # render_queue / alpha_method can invalidate their scenes' render
+        # caches. Weak so it never keeps objects alive. Initialised before any
+        # property setter below can call ``_derive_render_queue``.
+        self._users = weakref.WeakSet()
 
         self._store.uniform_buffer = Buffer(
             array_from_shadertype(self.uniform_type), force_contiguous=True
@@ -604,6 +611,20 @@ class Material(Trackable):
             else:  # alpha_method in ["blended", "weighted"]
                 render_queue = 3000
         self._render_queue = render_queue
+        # render_queue / alpha_method feed FlatScene sort keys; invalidate the
+        # render cache of every scene this material is used in.
+        for wobject in self._users:
+            wobject._bump_render_version()
+
+    def _register_user(self, wobject) -> None:
+        """Called by ``WorldObject.material`` setter when this material is
+        assigned to ``wobject``."""
+        self._users.add(wobject)
+
+    def _unregister_user(self, wobject) -> None:
+        """Called by ``WorldObject.material`` setter when this material is
+        replaced on ``wobject``."""
+        self._users.discard(wobject)
 
     def _get_alpha_config_options(
         self, method: str, keys: list, default_dict: dict, given_dict: dict

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -119,6 +119,7 @@ class _SubtreeIndex:
         "lights_spot",
         "renderable",
         "shadow_casters",
+        "version",
     )
 
     def __init__(self):
@@ -132,6 +133,10 @@ class _SubtreeIndex:
         # Set when a non-DFS-tail insertion leaves the lists out of
         # scene-graph order; cleared by a lazy reorder at render time.
         self._dfs_dirty = False
+        # Monotonic counter bumped whenever this subtree's render-relevant
+        # state changes; the renderer's per-scene cache compares it to know
+        # when to rebuild. Scoped to this object's subtree (no global state).
+        self.version = 0
 
     def add_object(self, obj: "WorldObject") -> None:
         """Insert ``obj`` into the relevant categorized lists."""
@@ -398,6 +403,21 @@ class WorldObject(EventTarget, Trackable):
             parent_ref = node._parent
             node = parent_ref() if parent_ref is not None else None
 
+    def _bump_render_version(self) -> None:
+        """Invalidate cached render structures for this object and every
+        ancestor (any of which a renderer may use as its scene root).
+
+        The version lives on each object's ``_subtree_index``, so this is
+        scoped to the affected subtree — there is no global state. Called from
+        the mutations that change which objects are renderable / lights /
+        shadow casters or their sort-key components. ``O(depth)``; mutations
+        are rare relative to render frames.
+        """
+        for node in self._iter_self_and_ancestors():
+            index = node._subtree_index
+            if index is not None:
+                index.version += 1
+
     def _refresh_caster_status(self) -> None:
         """Recompute self's shadow-caster status and propagate to every
         ancestor's ``shadow_casters`` list."""
@@ -516,6 +536,7 @@ class WorldObject(EventTarget, Trackable):
         self._cascade_topology_change(
             parent._effective_visible, parent._group_ref_for_my_children()
         )
+        self._bump_render_version()
 
     def _detach_subtree_from(self, parent: "WorldObject") -> None:
         """Apply the index/visibility/group bookkeeping for removing
@@ -532,6 +553,7 @@ class WorldObject(EventTarget, Trackable):
 
         # Cascade visibility + group ancestor as if self is now a root.
         self._cascade_topology_change(True, None)
+        self._bump_render_version()
 
     def _ensure_subtree_index_order(self) -> None:
         """Rebuild this object's index lists in scene-graph (DFS pre-order)
@@ -624,6 +646,7 @@ class WorldObject(EventTarget, Trackable):
     def visible(self, visible: bool) -> None:
         self._store.visible = bool(visible)
         self._refresh_visibility_subtree()
+        self._bump_render_version()
 
     @property
     def render_order(self) -> float:
@@ -651,6 +674,7 @@ class WorldObject(EventTarget, Trackable):
     @render_order.setter
     def render_order(self, value: float) -> None:
         self._store.render_order = float(value)
+        self._bump_render_version()
 
     @property
     def render_mask(self):
@@ -676,6 +700,7 @@ class WorldObject(EventTarget, Trackable):
         self._store.geometry = geometry
         # Shadow-caster eligibility depends on geometry presence.
         self._refresh_caster_status()
+        self._bump_render_version()
 
     @property
     def material(self) -> Material | None:
@@ -691,9 +716,18 @@ class WorldObject(EventTarget, Trackable):
             raise TypeError(
                 f"WorldObject.geometry must be a Geometry object or None, not {material!r}"
             )
+        # Track which objects use a material, so an in-place change to the
+        # material's render_queue / alpha_method can invalidate their scenes'
+        # render caches (the material can't reach the scene otherwise).
+        old = getattr(self, "_material", None)
+        if old is not None:
+            old._unregister_user(self)
         self._material = material
+        if material is not None:
+            material._register_user(self)
         # Renderable eligibility depends on having a material.
         self._refresh_renderable_status()
+        self._bump_render_version()
 
     @property
     def cast_shadow(self) -> bool:
@@ -705,6 +739,7 @@ class WorldObject(EventTarget, Trackable):
     def cast_shadow(self, value: bool) -> None:
         self._cast_shadow = bool(value)
         self._refresh_caster_status()
+        self._bump_render_version()
 
     @property
     def receive_shadow(self) -> bool:

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -78,6 +78,121 @@ class IdProvider:
 id_provider = IdProvider()
 
 
+class _SubtreeIndex:
+    """Categorized flat lists of *descendants* of a world object.
+
+    Each ``WorldObject`` owns one of these. ``self`` is **not** an entry of
+    its own index (only its strict descendants are) — this keeps the index
+    free of reference cycles, so removed subtrees become unreachable as
+    soon as their parents drop them, without needing cyclic GC.
+
+    The renderer iterates these flat lists at render time instead of
+    walking the scene graph; the lists are kept in sync incrementally by
+    ``WorldObject.add``/``remove`` and by the relevant property setters
+    (``cast_shadow``, ``geometry``, ``material``).
+
+    The lists must be in scene-graph (DFS pre-order) order, because:
+    - ``all_objects`` order drives renderer-id assignment, and
+    - ``renderable`` order is the stable tiebreak for objects with equal
+      sort keys (e.g. coplanar transparent objects), so it must match what
+      the old depth-first walk produced.
+
+    Appending a freshly-added subtree keeps DFS order **as long as it is
+    grafted at the depth-first tail** (the common case: building a scene by
+    successive ``add``s, or filling a group before moving on). A non-tail
+    insertion — adding to a group that already has later siblings, or using
+    ``add(..., before=...)`` — would put entries in the wrong place, so it
+    instead sets ``_dfs_dirty`` and the order is rebuilt lazily on the next
+    render (see ``WorldObject._ensure_subtree_index_order``). This keeps the
+    no-traversal fast path for steady-state render loops while staying
+    correct under arbitrary mutation.
+
+    All stored values are ``None``; the dicts act as ordered sets.
+    """
+
+    __slots__ = (
+        "_dfs_dirty",
+        "all_objects",
+        "lights_ambient",
+        "lights_directional",
+        "lights_point",
+        "lights_spot",
+        "renderable",
+        "shadow_casters",
+    )
+
+    def __init__(self):
+        self.all_objects = {}
+        self.lights_point = {}
+        self.lights_directional = {}
+        self.lights_spot = {}
+        self.lights_ambient = {}
+        self.shadow_casters = {}
+        self.renderable = {}
+        # Set when a non-DFS-tail insertion leaves the lists out of
+        # scene-graph order; cleared by a lazy reorder at render time.
+        self._dfs_dirty = False
+
+    def add_object(self, obj: "WorldObject") -> None:
+        """Insert ``obj`` into the relevant categorized lists."""
+        self.all_objects[obj] = None
+        kind = obj._subtree_light_kind
+        if kind == "point":
+            self.lights_point[obj] = None
+        elif kind == "directional":
+            self.lights_directional[obj] = None
+        elif kind == "spot":
+            self.lights_spot[obj] = None
+        elif kind == "ambient":
+            self.lights_ambient[obj] = None
+        if obj._caster_in_index:
+            self.shadow_casters[obj] = None
+        if obj._renderable_in_index:
+            self.renderable[obj] = None
+
+    def remove_object(self, obj: "WorldObject") -> None:
+        """Remove ``obj`` from all categorized lists (no-op if absent)."""
+        self.all_objects.pop(obj, None)
+        kind = obj._subtree_light_kind
+        if kind == "point":
+            self.lights_point.pop(obj, None)
+        elif kind == "directional":
+            self.lights_directional.pop(obj, None)
+        elif kind == "spot":
+            self.lights_spot.pop(obj, None)
+        elif kind == "ambient":
+            self.lights_ambient.pop(obj, None)
+        self.shadow_casters.pop(obj, None)
+        self.renderable.pop(obj, None)
+
+    def merge_in(self, other: "_SubtreeIndex") -> None:
+        """Merge all of ``other``'s entries into ``self`` (preserving order)."""
+        self.all_objects.update(other.all_objects)
+        self.lights_point.update(other.lights_point)
+        self.lights_directional.update(other.lights_directional)
+        self.lights_spot.update(other.lights_spot)
+        self.lights_ambient.update(other.lights_ambient)
+        self.shadow_casters.update(other.shadow_casters)
+        self.renderable.update(other.renderable)
+
+    def remove_in(self, other: "_SubtreeIndex") -> None:
+        """Remove all of ``other``'s entries from ``self``."""
+        for ob in other.all_objects:
+            self.all_objects.pop(ob, None)
+        for ob in other.lights_point:
+            self.lights_point.pop(ob, None)
+        for ob in other.lights_directional:
+            self.lights_directional.pop(ob, None)
+        for ob in other.lights_spot:
+            self.lights_spot.pop(ob, None)
+        for ob in other.lights_ambient:
+            self.lights_ambient.pop(ob, None)
+        for ob in other.shadow_casters:
+            self.shadow_casters.pop(ob, None)
+        for ob in other.renderable:
+            self.renderable.pop(ob, None)
+
+
 class WorldObject(EventTarget, Trackable):
     """Base class for objects.
 
@@ -120,6 +235,18 @@ class WorldObject(EventTarget, Trackable):
 
     _FORWARD_IS_MINUS_Z = False  # Default is +Z (lights and cameras use -Z)
 
+    # Marker used by the incremental scene-graph index. Light subclasses set
+    # this to one of "point", "directional", "spot", "ambient" so the index
+    # can categorize them without isinstance checks (and without circular
+    # imports between _base.py and _lights.py).
+    _subtree_light_kind: ClassVar[str | None] = None
+
+    # Marker used by the index for ``Group``-aware ``render_order``
+    # propagation. ``Group`` (and its subclasses, e.g. ``Scene``) sets this
+    # to True so child objects can resolve the closest Group ancestor
+    # without isinstance checks.
+    _subtree_is_group: ClassVar[bool] = False
+
     _id = 0
 
     # The uniform type describes the structured info for this object, which represents
@@ -152,6 +279,17 @@ class WorldObject(EventTarget, Trackable):
 
         #: Subtrees of the scene graph that depend on this object.
         self._children: List[WorldObject] = []
+
+        # Incremental scene-graph index state. Initialised lazily after
+        # all property setters have run (some setters update the index, so
+        # we need them to be no-ops until ``_subtree_index`` is created).
+        self._subtree_index: _SubtreeIndex | None = None
+        self._caster_in_index = False
+        self._renderable_in_index = False
+        self._effective_visible = True
+        self._closest_group_ancestor_ref: weakref.ReferenceType[WorldObject] | None = (
+            None
+        )
 
         self.geometry = geometry
         self.material = material
@@ -198,6 +336,15 @@ class WorldObject(EventTarget, Trackable):
 
         self.name = name
 
+        # Now bootstrap the subtree index. By convention our index holds
+        # only our *descendants*, not ourselves; ``self`` is registered
+        # into ancestor indices when added to a parent. Keeping self out
+        # of its own index prevents reference cycles.
+        self._subtree_index = _SubtreeIndex()
+        self._caster_in_index = self._compute_is_shadow_caster()
+        self._renderable_in_index = self._material is not None
+        self._effective_visible = bool(self._store.visible)
+
     def _assign_renderer_id(self, id):
         if self._renderer_id == 0:
             assert id > 0
@@ -227,6 +374,203 @@ class WorldObject(EventTarget, Trackable):
             casting="unsafe",
         )
         self.uniform_buffer.update_full()
+
+    # ----- Incremental scene-graph index helpers -----
+
+    def _compute_is_shadow_caster(self) -> bool:
+        """Whether self qualifies as a shadow caster right now."""
+        return bool(self.cast_shadow) and self._store.geometry is not None
+
+    def _iter_self_and_ancestors(self):
+        """Yield self, then each ancestor walking up the parent chain."""
+        node = self
+        while node is not None:
+            yield node
+            parent_ref = node._parent
+            node = parent_ref() if parent_ref is not None else None
+
+    def _iter_ancestors(self):
+        """Yield each strict ancestor (parent, grandparent, ...)."""
+        parent_ref = self._parent
+        node = parent_ref() if parent_ref is not None else None
+        while node is not None:
+            yield node
+            parent_ref = node._parent
+            node = parent_ref() if parent_ref is not None else None
+
+    def _refresh_caster_status(self) -> None:
+        """Recompute self's shadow-caster status and propagate to every
+        ancestor's ``shadow_casters`` list."""
+        if self._subtree_index is None:
+            return  # still in __init__, nothing to register against
+        new_caster = self._compute_is_shadow_caster()
+        if new_caster == self._caster_in_index:
+            return
+        self._caster_in_index = new_caster
+        for ancestor in self._iter_ancestors():
+            casters = ancestor._subtree_index.shadow_casters
+            if new_caster:
+                casters[self] = None
+            else:
+                casters.pop(self, None)
+
+    def _refresh_renderable_status(self) -> None:
+        """Recompute self's renderable status and propagate to every
+        ancestor's ``renderable`` list."""
+        if self._subtree_index is None:
+            return
+        new_renderable = self._material is not None
+        if new_renderable == self._renderable_in_index:
+            return
+        self._renderable_in_index = new_renderable
+        for ancestor in self._iter_ancestors():
+            renderable = ancestor._subtree_index.renderable
+            if new_renderable:
+                renderable[self] = None
+            else:
+                renderable.pop(self, None)
+
+    def _refresh_visibility_subtree(self) -> None:
+        """Recompute ``_effective_visible`` for self and, if it changed,
+        cascade to descendants. Called from the ``visible`` setter."""
+        if self._subtree_index is None:
+            return
+        parent = self.parent
+        parent_eff = parent._effective_visible if parent is not None else True
+        new_eff = parent_eff and bool(self._store.visible)
+        if new_eff == self._effective_visible:
+            return
+        self._effective_visible = new_eff
+        for child in self._children:
+            child._refresh_visibility_subtree()
+
+    def _cascade_topology_change(
+        self,
+        parent_eff_visible: bool,
+        parent_closest_group_ref: "weakref.ReferenceType[WorldObject] | None",
+    ) -> None:
+        """Recompute ``_effective_visible`` and ``_closest_group_ancestor_ref``
+        for self and all descendants.
+
+        Called when a subtree is attached to a new parent, or detached.
+        The caller passes the parent's effective-visibility and the
+        weakref to the parent's closest-Group-ancestor *for self*. (If
+        the new parent is itself a Group, the parent is self's closest
+        Group ancestor.)
+        """
+        self._effective_visible = parent_eff_visible and bool(self._store.visible)
+        self._closest_group_ancestor_ref = parent_closest_group_ref
+
+        if self._subtree_is_group:
+            child_group_ref = weakref.ref(self)
+        else:
+            child_group_ref = parent_closest_group_ref
+
+        for child in self._children:
+            child._cascade_topology_change(self._effective_visible, child_group_ref)
+
+    def _group_ref_for_my_children(
+        self,
+    ) -> "weakref.ReferenceType[WorldObject] | None":
+        """The closest-Group-ancestor weakref to give to a child being
+        attached under self.
+
+        If self is a Group, that's a weakref to self; otherwise it's
+        whatever self's own closest-Group-ancestor is.
+        """
+        if self._subtree_is_group:
+            return weakref.ref(self)
+        return self._closest_group_ancestor_ref
+
+    def _attach_subtree_under(self, parent: "WorldObject") -> None:
+        """Apply the index/visibility/group bookkeeping for adopting
+        ``self`` (with its existing subtree) as a freshly-added child of
+        ``parent``.
+
+        Precondition: ``self._parent`` already points to ``parent`` and
+        ``self`` is in ``parent._children``.
+        """
+        # Push self + its descendants up through every ancestor's index.
+        # ``self`` is registered explicitly because it is not present in
+        # its own ``_subtree_index`` (descendants only).
+        #
+        # Appending keeps DFS pre-order only while the new subtree is
+        # grafted at the depth-first tail, i.e. every node on the path from
+        # the ancestor down to ``self`` is the last child of its parent.
+        # ``at_tail`` tracks that; once it fails for an ancestor, that
+        # ancestor (and every higher one) is marked dirty for a lazy
+        # reorder at render time.
+        own_index = self._subtree_index
+        at_tail = True
+        child = self
+        for ancestor in parent._iter_self_and_ancestors():
+            anc_index = ancestor._subtree_index
+            anc_index.add_object(self)
+            anc_index.merge_in(own_index)
+            if not (at_tail and ancestor._children[-1] is child):
+                at_tail = False
+                anc_index._dfs_dirty = True
+            child = ancestor
+
+        # Cascade visibility + group ancestor down through the new subtree.
+        self._cascade_topology_change(
+            parent._effective_visible, parent._group_ref_for_my_children()
+        )
+
+    def _detach_subtree_from(self, parent: "WorldObject") -> None:
+        """Apply the index/visibility/group bookkeeping for removing
+        ``self`` (with its subtree) from ``parent``.
+
+        Precondition: ``self`` has been removed from ``parent._children``
+        but ``self._parent`` has not yet been cleared.
+        """
+        own_index = self._subtree_index
+        for ancestor in parent._iter_self_and_ancestors():
+            anc_index = ancestor._subtree_index
+            anc_index.remove_object(self)
+            anc_index.remove_in(own_index)
+
+        # Cascade visibility + group ancestor as if self is now a root.
+        self._cascade_topology_change(True, None)
+
+    def _ensure_subtree_index_order(self) -> None:
+        """Rebuild this object's index lists in scene-graph (DFS pre-order)
+        order if a non-tail insertion left them dirty.
+
+        This is a no-op in the common case — appends at the depth-first tail
+        keep the lists ordered, so ``_dfs_dirty`` stays clear and a
+        steady-state render loop never walks the graph. Removals preserve the
+        relative order of the remaining entries, so only insertions can dirty
+        the index. When dirty, this costs one O(N) walk of the subtree, paid
+        once on the first render after the mutation.
+        """
+        index = self._subtree_index
+        if index is None or not index._dfs_dirty:
+            return
+
+        # Depth-first pre-order over the descendants (self is excluded from
+        # its own index by design).
+        ordered = {}
+        stack = self._children[::-1]
+        while stack:
+            node = stack.pop()
+            ordered[node] = None
+            children = node._children
+            if children:
+                stack.extend(children[::-1])
+
+        # Reorder each categorized list to follow ``ordered`` while keeping
+        # its existing membership (built incrementally and already correct).
+        index.all_objects = ordered
+        index.renderable = {o: None for o in ordered if o in index.renderable}
+        index.shadow_casters = {o: None for o in ordered if o in index.shadow_casters}
+        index.lights_point = {o: None for o in ordered if o in index.lights_point}
+        index.lights_directional = {
+            o: None for o in ordered if o in index.lights_directional
+        }
+        index.lights_spot = {o: None for o in ordered if o in index.lights_spot}
+        index.lights_ambient = {o: None for o in ordered if o in index.lights_ambient}
+        index._dfs_dirty = False
 
     def __repr__(self):
         return f"<pygfx.{self.__class__.__name__} {self.name} at {hex(id(self))}>"
@@ -279,6 +623,7 @@ class WorldObject(EventTarget, Trackable):
     @visible.setter
     def visible(self, visible: bool) -> None:
         self._store.visible = bool(visible)
+        self._refresh_visibility_subtree()
 
     @property
     def render_order(self) -> float:
@@ -329,6 +674,8 @@ class WorldObject(EventTarget, Trackable):
                 f"WorldObject.geometry must be a Geometry object or None, not {geometry!r}"
             )
         self._store.geometry = geometry
+        # Shadow-caster eligibility depends on geometry presence.
+        self._refresh_caster_status()
 
     @property
     def material(self) -> Material | None:
@@ -345,6 +692,8 @@ class WorldObject(EventTarget, Trackable):
                 f"WorldObject.geometry must be a Geometry object or None, not {material!r}"
             )
         self._material = material
+        # Renderable eligibility depends on having a material.
+        self._refresh_renderable_status()
 
     @property
     def cast_shadow(self) -> bool:
@@ -355,6 +704,7 @@ class WorldObject(EventTarget, Trackable):
     @cast_shadow.setter
     def cast_shadow(self, value: bool) -> None:
         self._cast_shadow = bool(value)
+        self._refresh_caster_status()
 
     @property
     def receive_shadow(self) -> bool:
@@ -452,6 +802,12 @@ class WorldObject(EventTarget, Trackable):
             if keep_world_matrix:
                 obj.world.matrix = transform_matrix
 
+            # Update the incremental scene-graph index. ``obj`` arrived as a
+            # root (its prior parent, if any, was removed above), so its
+            # ``_subtree_index`` already describes exactly the subtree to
+            # graft in.
+            obj._attach_subtree_under(self)
+
         return self
 
     def remove(self, *objects: WorldObject, keep_world_matrix: bool = False) -> None:
@@ -464,12 +820,16 @@ class WorldObject(EventTarget, Trackable):
                 logger.warning("Attempting to remove object that was not a child.")
                 continue
             else:
+                # Detach from the index BEFORE clearing the parent ref, so
+                # we can still walk the ancestor chain.
+                obj._detach_subtree_from(self)
                 obj._reset_parent(keep_world_matrix=keep_world_matrix)
 
     def clear(self, *, keep_world_matrix: bool = False) -> None:
         """Removes all children."""
 
         for child in self._children:
+            child._detach_subtree_from(self)
             child._reset_parent(keep_world_matrix=keep_world_matrix)
 
         self._children.clear()

--- a/pygfx/objects/_lights.py
+++ b/pygfx/objects/_lights.py
@@ -126,6 +126,10 @@ class Light(WorldObject):
     @cast_shadow.setter
     def cast_shadow(self, value: bool):
         self.uniform_buffer.data["cast_shadow"] = bool(value)
+        # Lights typically have no geometry (so they don't enter the
+        # shadow-caster index), but call the hook regardless to keep the
+        # invariant that any cast_shadow change refreshes the index.
+        self._refresh_caster_status()
 
 
 class AmbientLight(Light):
@@ -142,6 +146,8 @@ class AmbientLight(Light):
         scene.
 
     """
+
+    _subtree_light_kind = "ambient"
 
     def __init__(self, color="#ffffff", intensity=0.2):
         super().__init__(color, intensity)
@@ -176,6 +182,8 @@ class PointLight(Light):
     profile.
 
     """
+
+    _subtree_light_kind = "point"
 
     uniform_type = dict(
         Light.uniform_type,
@@ -273,6 +281,8 @@ class DirectionalLight(Light):
 
     """
 
+    _subtree_light_kind = "directional"
+
     uniform_type = dict(
         Light.uniform_type,
         direction="4xf4",
@@ -358,6 +368,8 @@ class SpotLight(Light):
     profile.
 
     """
+
+    _subtree_light_kind = "spot"
 
     uniform_type = dict(
         Light.uniform_type,

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -23,6 +23,11 @@ class Group(WorldObject):
 
     """
 
+    # Marker for the incremental scene-graph index: descendants treat
+    # ``Group`` (and its subclasses, e.g. ``Scene``) as the source of
+    # their ``group_order`` (the closest Group ancestor's render_order).
+    _subtree_is_group = True
+
     def __init__(self, *, visible=True, name=""):
         super().__init__(visible=visible, name=name)
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -59,6 +59,7 @@ class FlatScene:
     def __init__(self, scene, view_matrix=None, object_count=0):
         self._view_matrix = view_matrix
         self._wobject_wrappers = []  # WobjectWrapper's
+        self._sort_arrays = None  # (render_queue, group_order, render_order, dist)
         self.lights = {
             "point_lights": [],
             "directional_lights": [],
@@ -167,54 +168,89 @@ class FlatScene:
             if wobject._effective_visible:
                 renderables_iter.append(wobject)
 
-        for wobject in renderables_iter:
-            # ``group_order`` was previously propagated by the recursive
-            # walk; now we read it via the cached weakref to the closest
-            # Group ancestor (kept in sync on add/remove).
-            group_ref = wobject._closest_group_ancestor_ref
-            group_order = 0
-            if group_ref is not None:
-                group_ob = group_ref()
-                if group_ob is not None:
-                    group_order = group_ob.render_order
+        if view_matrix is None:
+            # No depth sort to do: ``dist_flag`` is a constant (0 for weighted
+            # blending, else -1), so the per-object Python path is lightest —
+            # vectorizing buys nothing without a real distance to compute.
+            for wobject in renderables_iter:
+                material = wobject._material
+                if material is None:
+                    continue
+                group_ref = wobject._closest_group_ancestor_ref
+                group_ob = group_ref() if group_ref is not None else None
+                group_order = group_ob.render_order if group_ob is not None else 0
+                dist_flag = 0 if material.alpha_method == "weighted" else -1
+                sort_key = (material.render_queue, group_order,
+                            wobject.render_order, dist_flag)
+                wobject_wrappers.append(
+                    WobjectWrapper(wobject, sort_key, material.alpha_method)
+                )
+            self._sort_arrays = None  # -> sort() uses the tuple path
+            return
 
+        # Depth sort with a moving camera is the hot path: the per-object
+        # distance-to-camera (``vec_transform``) and the final sort are done
+        # in bulk with NumPy rather than once per object. Gather the sort-key
+        # components into Python lists (cheap appends), transform all
+        # positions in a single matmul, and let ``sort()`` do one
+        # ``np.lexsort``. Bit-identical to the old per-object path (lexsort is
+        # stable, so equal keys keep scene-graph order).
+        group_order_l = []
+        render_order_l = []
+        sign_l = []
+        weighted_l = []
+        render_queue_l = []
+        positions_l = []
+        for wobject in renderables_iter:
             material = wobject._material
-            # ``renderable`` only contains objects with a material, but
-            # the flag is updated lazily via setters, so be defensive.
             if material is None:
                 continue
-
+            group_ref = wobject._closest_group_ancestor_ref
+            group_ob = group_ref() if group_ref is not None else None
             render_queue = material.render_queue
-            alpha_method = material.alpha_method
+            render_queue_l.append(render_queue)
+            group_order_l.append(group_ob.render_order if group_ob is not None else 0)
+            render_order_l.append(wobject.render_order)
+            # Back-to-front by default; front-to-back for opaque queues.
+            sign_l.append(1.0 if 1500 < render_queue <= 2500 else -1.0)
+            weighted_l.append(material.alpha_method == "weighted")
+            positions_l.append(wobject.world.position)
+            wobject_wrappers.append(
+                WobjectWrapper(wobject, None, material.alpha_method)
+            )
 
-            # By default sort back-to-front, for correct blending.
-            dist_sort_sign = -1
-            # But for opaque queues, render front-to-back to avoid overdraw.
-            if 1500 < render_queue <= 2500:
-                dist_sort_sign = 1
+        if not positions_l:
+            self._sort_arrays = None
+            return
+        relative = la.vec_transform(
+            np.asarray(positions_l, np.float64), view_matrix, projection=False
+        )
+        dist_a = -relative[:, 2] * np.array(sign_l, np.float64)
+        # ``weighted`` blending ignores depth (dist_flag 0).
+        if any(weighted_l):
+            dist_a[np.array(weighted_l, bool)] = 0.0
 
-            pass_type = alpha_method
-
-            # Depth sort flag. Use the camera's view matrix (projection
-            # doesn't affect ordering, allowing projection=False).
-            # Camera looks down -z.
-            if alpha_method == "weighted":
-                dist_flag = 0
-            elif view_matrix is None:
-                dist_flag = -1
-            else:
-                relative_pos = la.vec_transform(
-                    wobject.world.position, view_matrix, projection=False
-                )
-                distance_to_camera = float(-relative_pos[2])
-                dist_flag = distance_to_camera * dist_sort_sign
-
-            sort_key = (render_queue, group_order, wobject.render_order, dist_flag)
-            wobject_wrappers.append(WobjectWrapper(wobject, sort_key, pass_type))
+        # Stored for ``sort()``; parallel to ``self._wobject_wrappers``.
+        self._sort_arrays = (
+            np.array(render_queue_l, np.int64),
+            np.array(group_order_l, np.float64),
+            np.array(render_order_l, np.float64),
+            dist_a,
+        )
 
     def sort(self):
-        """Sort the world objects."""
-        self._wobject_wrappers.sort(key=lambda ob: ob.sort_key)
+        """Sort the world objects (stable depth sort)."""
+        arrays = self._sort_arrays
+        if arrays is None:
+            # No-camera path: wrappers carry tuple sort keys.
+            self._wobject_wrappers.sort(key=lambda ob: ob.sort_key)
+            return
+        render_queue_a, group_order_a, render_order_a, dist_a = arrays
+        # lexsort: last key is primary -> (render_queue, group_order,
+        # render_order, dist), ascending, stable.
+        order = np.lexsort((dist_a, render_order_a, group_order_a, render_queue_a))
+        wrappers = self._wobject_wrappers
+        self._wobject_wrappers = [wrappers[i] for i in order]
 
     def collect_pipelines_container_groups(self, renderstate):
         """Select and resolve the pipeline, compiling shaders, building pipelines and composing binding as needed."""

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -21,14 +21,6 @@ from ....objects import (
     WheelEvent,
     WindowEvent,
     WorldObject,
-    Group,
-)
-from ....objects._lights import (
-    Light,
-    PointLight,
-    DirectionalLight,
-    SpotLight,
-    AmbientLight,
 )
 from ....cameras import Camera
 from ....resources import Texture
@@ -78,82 +70,147 @@ class FlatScene:
         self.scene = scene
         self.add_scene(scene)
 
-    def _iter_scene(self, ob, group_order=0):
-        if not ob.visible:
-            return
-
-        if isinstance(ob, Group):
-            group_order = ob.render_order
-
-        yield ob, group_order
-        for child in ob._children:
-            yield from self._iter_scene(child, group_order)
-
     def add_scene(self, scene):
-        """Add a scene to the total flat scene. Is usually called just once."""
+        """Add a scene to the total flat scene. Is usually called just once.
+
+        This reads pre-categorized flat lists from ``scene._subtree_index``
+        (maintained incrementally by ``WorldObject.add``/``remove``) so
+        that no scene-graph traversal is needed at render time.
+
+        ``scene`` itself is **not** an entry of ``scene._subtree_index``
+        (the index covers descendants only, by design — see
+        ``_SubtreeIndex``), so we process ``scene`` separately and then
+        the descendants.
+        """
 
         # Put some attributes as vars in this namespace for faster access
         view_matrix = self._view_matrix
         wobject_wrappers = self._wobject_wrappers
+        # Restore DFS pre-order if a non-tail mutation left the index dirty
+        # (cheap no-op in steady-state render loops).
+        scene._ensure_subtree_index_order()
+        index = scene._subtree_index
 
-        for wobject, group_order in self._iter_scene(scene):
-            # Dereference the object in case its a weak proxy
+        # Visible lights, by type. Visibility is dynamic (and ancestors
+        # can hide a subtree), so we filter via the cached
+        # ``_effective_visible`` flag, which the index keeps up-to-date.
+        # The index excludes ``scene`` itself; if scene happens to be a
+        # light, fold its contribution in too.
+        scene_kind = scene._subtree_light_kind
+        scene_visible = scene._effective_visible
+
+        point_lights = self.lights["point_lights"]
+        if scene_visible and scene_kind == "point":
+            point_lights.append(scene)
+        for light in index.lights_point:
+            if light._effective_visible:
+                point_lights.append(light)
+
+        directional_lights = self.lights["directional_lights"]
+        if scene_visible and scene_kind == "directional":
+            directional_lights.append(scene)
+        for light in index.lights_directional:
+            if light._effective_visible:
+                directional_lights.append(light)
+
+        spot_lights = self.lights["spot_lights"]
+        if scene_visible and scene_kind == "spot":
+            spot_lights.append(scene)
+        for light in index.lights_spot:
+            if light._effective_visible:
+                spot_lights.append(light)
+
+        # Ambient lights: aggregate physical color contributions.
+        ambient_color = self.lights["ambient_color"]
+        if scene_visible and scene_kind == "ambient":
+            r, g, b = scene.color.to_physical()
+            ambient_color[0] += r * scene.intensity
+            ambient_color[1] += g * scene.intensity
+            ambient_color[2] += b * scene.intensity
+        for light in index.lights_ambient:
+            if not light._effective_visible:
+                continue
+            r, g, b = light.color.to_physical()
+            ambient_color[0] += r * light.intensity
+            ambient_color[1] += g * light.intensity
+            ambient_color[2] += b * light.intensity
+
+        # Per-object updates: assign renderer ids and refresh transforms
+        # for every visible object, including non-renderable ones (Groups,
+        # cameras nested in the scene, helpers, etc.) — matching the
+        # prior traversal-based behaviour.
+        if scene_visible:
+            scene_obj = scene._self()
+            self.object_count += scene_obj._assign_renderer_id(self.object_count + 1)
+            scene_obj._update_object()
+        for wobject in index.all_objects:
+            if not wobject._effective_visible:
+                continue
             wobject = wobject._self()
-            # Assign renderer id's
             self.object_count += wobject._assign_renderer_id(self.object_count + 1)
-            # Update things like transform and uniform buffers
             wobject._update_object()
 
-            # Light objects
-            if isinstance(wobject, Light):
-                if isinstance(wobject, PointLight):
-                    self.lights["point_lights"].append(wobject)
-                elif isinstance(wobject, DirectionalLight):
-                    self.lights["directional_lights"].append(wobject)
-                elif isinstance(wobject, SpotLight):
-                    self.lights["spot_lights"].append(wobject)
-                elif isinstance(wobject, AmbientLight):
-                    r, g, b = wobject.color.to_physical()
-                    ambient_color = self.lights["ambient_color"]
-                    ambient_color[0] += r * wobject.intensity
-                    ambient_color[1] += g * wobject.intensity
-                    ambient_color[2] += b * wobject.intensity
+        # Shadow casters (objects with cast_shadow and a geometry).
+        shadow_objects = self.shadow_objects
+        if scene_visible and scene._caster_in_index:
+            shadow_objects.append(scene)
+        for wobject in index.shadow_casters:
+            if wobject._effective_visible:
+                shadow_objects.append(wobject)
 
-            # Shadowable objects
-            if wobject.cast_shadow and wobject.geometry is not None:
-                self.shadow_objects.append(wobject)
+        # Renderable objects: build wrappers + sort keys. Iterate scene
+        # itself first (if applicable), then descendants from the index.
+        renderables_iter: "list" = []
+        if scene_visible and scene._renderable_in_index:
+            renderables_iter.append(scene)
+        for wobject in index.renderable:
+            if wobject._effective_visible:
+                renderables_iter.append(wobject)
 
-            # Renderable objects
+        for wobject in renderables_iter:
+            # ``group_order`` was previously propagated by the recursive
+            # walk; now we read it via the cached weakref to the closest
+            # Group ancestor (kept in sync on add/remove).
+            group_ref = wobject._closest_group_ancestor_ref
+            group_order = 0
+            if group_ref is not None:
+                group_ob = group_ref()
+                if group_ob is not None:
+                    group_order = group_ob.render_order
+
             material = wobject._material
-            if material is not None:
-                render_queue = material.render_queue
-                alpha_method = material.alpha_method
+            # ``renderable`` only contains objects with a material, but
+            # the flag is updated lazily via setters, so be defensive.
+            if material is None:
+                continue
 
-                # By default sort back-to-front, for correct blending.
-                dist_sort_sign = -1
-                # But for opaque queues, render front-to-back to avoid overdraw.
-                if 1500 < render_queue <= 2500:
-                    dist_sort_sign = 1
+            render_queue = material.render_queue
+            alpha_method = material.alpha_method
 
-                pass_type = alpha_method
+            # By default sort back-to-front, for correct blending.
+            dist_sort_sign = -1
+            # But for opaque queues, render front-to-back to avoid overdraw.
+            if 1500 < render_queue <= 2500:
+                dist_sort_sign = 1
 
-                # Get depth sorting flag. Note that use camera's view matrix, since the projection does not affect the depth order.
-                # It also means we can set projection=False optimalization.
-                # Also note that we look down -z.
-                if alpha_method == "weighted":
-                    dist_flag = 0
-                elif view_matrix is None:
-                    dist_flag = -1
-                else:
-                    relative_pos = la.vec_transform(
-                        wobject.world.position, view_matrix, projection=False
-                    )
-                    # Cam looks towards -z: negate to get distance
-                    distance_to_camera = float(-relative_pos[2])
-                    dist_flag = distance_to_camera * dist_sort_sign
+            pass_type = alpha_method
 
-                sort_key = (render_queue, group_order, wobject.render_order, dist_flag)
-                wobject_wrappers.append(WobjectWrapper(wobject, sort_key, pass_type))
+            # Depth sort flag. Use the camera's view matrix (projection
+            # doesn't affect ordering, allowing projection=False).
+            # Camera looks down -z.
+            if alpha_method == "weighted":
+                dist_flag = 0
+            elif view_matrix is None:
+                dist_flag = -1
+            else:
+                relative_pos = la.vec_transform(
+                    wobject.world.position, view_matrix, projection=False
+                )
+                distance_to_camera = float(-relative_pos[2])
+                dist_flag = distance_to_camera * dist_sort_sign
+
+            sort_key = (render_queue, group_order, wobject.render_order, dist_flag)
+            wobject_wrappers.append(WobjectWrapper(wobject, sort_key, pass_type))
 
     def sort(self):
         """Sort the world objects."""

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -55,6 +55,124 @@ class WobjectWrapper:
         self.render_containers = None
 
 
+class _RenderableCache:
+    """Camera-independent renderable data for one scene, cached across frames.
+
+    Building this is the expensive part of the render loop (walking the index,
+    reading each material's render_queue / alpha_method, allocating wrappers).
+    None of it depends on the camera, so it is kept on the scene and reused
+    while the scene's ``_subtree_index.version`` is unchanged (bumped by the
+    scene-graph / material mutations that affect it). Only the depth (camera
+    distance) is recomputed per frame; object *positions* are refreshed
+    incrementally via ``transform.last_modified`` so that moving objects don't
+    force a full rebuild.
+    """
+
+    __slots__ = (
+        "all_renderable_row",
+        "all_stamps",
+        "all_wobjects",
+        "dist_no_camera",
+        "group_order",
+        "has_weighted",
+        "positions",
+        "render_order",
+        "render_queue",
+        "sign",
+        "version",
+        "weighted",
+        "wobjects",
+        "wrappers",
+    )
+
+    @classmethod
+    def build(cls, scene, scene_visible, index):
+        self = cls()
+        renderables = []
+        if scene_visible and scene._renderable_in_index:
+            renderables.append(scene)
+        for wobject in index.renderable:
+            if wobject._effective_visible:
+                renderables.append(wobject)
+
+        wobjects, wrappers = [], []
+        rq_l, go_l, ro_l, sign_l, w_l, pos_l = [], [], [], [], [], []
+        for wobject in renderables:
+            material = wobject._material
+            if material is None:  # cleared concurrently; skip
+                continue
+            group_ref = wobject._closest_group_ancestor_ref
+            group_ob = group_ref() if group_ref is not None else None
+            render_queue = material.render_queue
+            rq_l.append(render_queue)
+            go_l.append(group_ob.render_order if group_ob is not None else 0)
+            ro_l.append(wobject.render_order)
+            sign_l.append(1.0 if 1500 < render_queue <= 2500 else -1.0)
+            w_l.append(material.alpha_method == "weighted")
+            pos_l.append(wobject.world.position)
+            wobjects.append(wobject)
+            wrappers.append(WobjectWrapper(wobject, None, material.alpha_method))
+
+        self.wobjects = wobjects
+        self.wrappers = wrappers
+        self.render_queue = np.array(rq_l, np.int64)
+        self.group_order = np.array(go_l, np.float64)
+        self.render_order = np.array(ro_l, np.float64)
+        self.sign = np.array(sign_l, np.float64)
+        self.weighted = np.array(w_l, bool)
+        self.has_weighted = bool(self.weighted.any()) if w_l else False
+        self.positions = (
+            np.asarray(pos_l, np.float64) if pos_l else np.empty((0, 3), np.float64)
+        )
+        # Depth flag when there is no camera: -1 everywhere, 0 for weighted.
+        dist = np.full(len(wobjects), -1.0)
+        if self.has_weighted:
+            dist[self.weighted] = 0.0
+        self.dist_no_camera = dist
+
+        # All visible objects (not just renderables) need a renderer-id and a
+        # per-frame transform refresh. Cache that list too, plus for each entry
+        # the row into ``positions`` if it is a renderable (else -1), so the
+        # per-frame pass updates transforms and renderable positions in one
+        # sweep. ``all_stamps`` starts at -1 so the first frame after a (re)build
+        # runs ``_update_object`` for everything (syncing uniforms).
+        row_of = {w: r for r, w in enumerate(wobjects)}
+        all_raw = [scene] if scene_visible else []
+        all_raw += [w for w in index.all_objects if w._effective_visible]
+        self.all_renderable_row = np.array(
+            [row_of.get(w, -1) for w in all_raw], np.int64
+        )
+        # ``_self()`` derefs a possible weakproxy (e.g. FastPlotLib), matching
+        # the historical per-object loop; it is identity for normal objects.
+        self.all_wobjects = [w._self() for w in all_raw]
+        self.all_stamps = np.full(len(all_raw), -1, np.int64)
+        return self
+
+    def update_objects(self, object_count, need_pos):
+        """Per-frame sweep over every visible object: assign renderer-ids to
+        new objects and run ``_update_object`` only for those whose transform
+        changed since last frame, refreshing cached renderable positions in the
+        same pass. Returns the new ``object_count``."""
+        stamps = self.all_stamps
+        rows = self.all_renderable_row
+        positions = self.positions
+        allw = self.all_wobjects
+        for i in range(len(allw)):
+            wobject = allw[i]
+            if wobject._renderer_id == 0:
+                object_count += 1
+                wobject._assign_renderer_id(object_count)
+            lm = wobject.world.last_modified
+            if lm != stamps[i]:
+                wobject._update_object()
+                stamps[i] = lm
+                if need_pos:
+                    r = rows[i]
+                    if r >= 0:
+                        positions[r] = wobject.world.position
+        return object_count
+
+
 class FlatScene:
     def __init__(self, scene, view_matrix=None, object_count=0):
         self._view_matrix = view_matrix
@@ -86,7 +204,6 @@ class FlatScene:
 
         # Put some attributes as vars in this namespace for faster access
         view_matrix = self._view_matrix
-        wobject_wrappers = self._wobject_wrappers
         # Restore DFS pre-order if a non-tail mutation left the index dirty
         # (cheap no-op in steady-state render loops).
         scene._ensure_subtree_index_order()
@@ -136,20 +253,24 @@ class FlatScene:
             ambient_color[1] += g * light.intensity
             ambient_color[2] += b * light.intensity
 
-        # Per-object updates: assign renderer ids and refresh transforms
-        # for every visible object, including non-renderable ones (Groups,
-        # cameras nested in the scene, helpers, etc.) — matching the
-        # prior traversal-based behaviour.
-        if scene_visible:
-            scene_obj = scene._self()
-            self.object_count += scene_obj._assign_renderer_id(self.object_count + 1)
-            scene_obj._update_object()
-        for wobject in index.all_objects:
-            if not wobject._effective_visible:
-                continue
-            wobject = wobject._self()
-            self.object_count += wobject._assign_renderer_id(self.object_count + 1)
-            wobject._update_object()
+        # Renderable objects: the camera-independent part (which objects,
+        # their wrappers and sort-key components) is cached on the scene and
+        # reused across frames while the scene's index version is unchanged.
+        # Only the depth sort key (camera distance) is computed per frame.
+        cache = getattr(scene, "_renderable_cache", None)
+        version = index.version
+        if cache is None or cache.version != version:
+            cache = _RenderableCache.build(scene, scene_visible, index)
+            cache.version = version
+            scene._renderable_cache = cache
+
+        need_pos = view_matrix is not None
+
+        # Per-object pass over every visible object (incl. groups/cameras):
+        # assign renderer-ids to new objects and run ``_update_object`` only
+        # for those whose transform changed, refreshing cached renderable
+        # positions in the same sweep. Replaces the old full per-frame loop.
+        self.object_count = cache.update_objects(self.object_count, need_pos)
 
         # Shadow casters (objects with cast_shadow and a geometry).
         shadow_objects = self.shadow_objects
@@ -159,91 +280,30 @@ class FlatScene:
             if wobject._effective_visible:
                 shadow_objects.append(wobject)
 
-        # Renderable objects: build wrappers + sort keys. Iterate scene
-        # itself first (if applicable), then descendants from the index.
-        renderables_iter: "list" = []
-        if scene_visible and scene._renderable_in_index:
-            renderables_iter.append(scene)
-        for wobject in index.renderable:
-            if wobject._effective_visible:
-                renderables_iter.append(wobject)
-
-        if view_matrix is None:
-            # No depth sort to do: ``dist_flag`` is a constant (0 for weighted
-            # blending, else -1), so the per-object Python path is lightest —
-            # vectorizing buys nothing without a real distance to compute.
-            for wobject in renderables_iter:
-                material = wobject._material
-                if material is None:
-                    continue
-                group_ref = wobject._closest_group_ancestor_ref
-                group_ob = group_ref() if group_ref is not None else None
-                group_order = group_ob.render_order if group_ob is not None else 0
-                dist_flag = 0 if material.alpha_method == "weighted" else -1
-                sort_key = (material.render_queue, group_order,
-                            wobject.render_order, dist_flag)
-                wobject_wrappers.append(
-                    WobjectWrapper(wobject, sort_key, material.alpha_method)
-                )
-            self._sort_arrays = None  # -> sort() uses the tuple path
-            return
-
-        # Depth sort with a moving camera is the hot path: the per-object
-        # distance-to-camera (``vec_transform``) and the final sort are done
-        # in bulk with NumPy rather than once per object. Gather the sort-key
-        # components into Python lists (cheap appends), transform all
-        # positions in a single matmul, and let ``sort()`` do one
-        # ``np.lexsort``. Bit-identical to the old per-object path (lexsort is
-        # stable, so equal keys keep scene-graph order).
-        group_order_l = []
-        render_order_l = []
-        sign_l = []
-        weighted_l = []
-        render_queue_l = []
-        positions_l = []
-        for wobject in renderables_iter:
-            material = wobject._material
-            if material is None:
-                continue
-            group_ref = wobject._closest_group_ancestor_ref
-            group_ob = group_ref() if group_ref is not None else None
-            render_queue = material.render_queue
-            render_queue_l.append(render_queue)
-            group_order_l.append(group_ob.render_order if group_ob is not None else 0)
-            render_order_l.append(wobject.render_order)
-            # Back-to-front by default; front-to-back for opaque queues.
-            sign_l.append(1.0 if 1500 < render_queue <= 2500 else -1.0)
-            weighted_l.append(material.alpha_method == "weighted")
-            positions_l.append(wobject.world.position)
-            wobject_wrappers.append(
-                WobjectWrapper(wobject, None, material.alpha_method)
-            )
-
-        if not positions_l:
+        self._wobject_wrappers = cache.wrappers
+        if not cache.wobjects:
             self._sort_arrays = None
             return
-        relative = la.vec_transform(
-            np.asarray(positions_l, np.float64), view_matrix, projection=False
-        )
-        dist_a = -relative[:, 2] * np.array(sign_l, np.float64)
-        # ``weighted`` blending ignores depth (dist_flag 0).
-        if any(weighted_l):
-            dist_a[np.array(weighted_l, bool)] = 0.0
 
-        # Stored for ``sort()``; parallel to ``self._wobject_wrappers``.
+        if not need_pos:
+            dist_a = cache.dist_no_camera
+        else:
+            relative = la.vec_transform(cache.positions, view_matrix, projection=False)
+            dist_a = -relative[:, 2] * cache.sign  # fresh array
+            if cache.has_weighted:
+                dist_a[cache.weighted] = 0.0
+
         self._sort_arrays = (
-            np.array(render_queue_l, np.int64),
-            np.array(group_order_l, np.float64),
-            np.array(render_order_l, np.float64),
+            cache.render_queue,
+            cache.group_order,
+            cache.render_order,
             dist_a,
         )
 
     def sort(self):
-        """Sort the world objects (stable depth sort)."""
+        """Sort the world objects (stable depth sort via ``np.lexsort``)."""
         arrays = self._sort_arrays
         if arrays is None:
-            # No-camera path: wrappers carry tuple sort keys.
-            self._wobject_wrappers.sort(key=lambda ob: ob.sort_key)
             return
         render_queue_a, group_order_a, render_order_a, dist_a = arrays
         # lexsort: last key is primary -> (render_queue, group_order,

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -163,6 +163,172 @@ def test_adjust_children_order():
         assert actual is expected
 
 
+def _ref_dfs(root):
+    """Reference depth-first pre-order of root's descendants (excludes root)."""
+    out = []
+
+    def walk(o):
+        for c in o._children:
+            out.append(c)
+            walk(c)
+
+    walk(root)
+    return out
+
+
+def _index_order(root):
+    root._ensure_subtree_index_order()
+    return list(root._subtree_index.all_objects)
+
+
+def test_subtree_index_dfs_order():
+    # The incremental scene-graph index must present descendants in the same
+    # depth-first pre-order the old full-walk produced, because that order
+    # drives renderer-id assignment and the stable tiebreak for equal sort
+    # keys. See pygfx issue #1298.
+
+    # Adding to a group that already has a later sibling (not the DFS tail).
+    root = WorldObject()
+    g1, g2 = WorldObject(), WorldObject()
+    root.add(g1, g2)
+    x = WorldObject()
+    g1.add(x)
+    assert _index_order(root) == _ref_dfs(root)
+    assert _index_order(root) == [g1, x, g2]
+
+    # before= insertion.
+    root = WorldObject()
+    a, b, c = WorldObject(), WorldObject(), WorldObject()
+    root.add(a, b)
+    root.add(c, before=a)
+    assert _index_order(root) == _ref_dfs(root) == [c, a, b]
+
+    # Reparenting a subtree to an earlier sibling.
+    root = WorldObject()
+    g1, g2 = WorldObject(), WorldObject()
+    root.add(g1, g2)
+    leaf = WorldObject()
+    g2.add(leaf)
+    g1.add(leaf)
+    assert _index_order(root) == _ref_dfs(root) == [g1, leaf, g2]
+
+
+def test_subtree_index_dfs_order_hard_cases():
+    # Move a *populated* subtree to an earlier position: its whole block must
+    # relocate in DFS order, not just its root.
+    root = WorldObject()
+    a, b = WorldObject(), WorldObject()
+    root.add(a, b)
+    sub = WorldObject()
+    s1, s2 = WorldObject(), WorldObject()
+    sub.add(s1, s2)
+    b.add(sub)  # sub currently under b (the tail) -> clean
+    assert _index_order(root) == _ref_dfs(root)
+    a.add(sub)  # move populated sub under a (earlier sibling) -> dirty
+    assert _index_order(root) == _ref_dfs(root) == [a, sub, s1, s2, b]
+
+    # Several non-tail mutations before a single render coalesce into one
+    # correct reorder.
+    root = WorldObject()
+    groups = [WorldObject() for _ in range(4)]
+    root.add(*groups)
+    leaves = [WorldObject() for _ in range(4)]
+    for g, leaf in zip(groups, leaves, strict=True):
+        g.add(leaf)  # each adds to a non-tail group (except the last)
+    assert _index_order(root) == _ref_dfs(root)
+
+    # The element whose insertion dirtied the index is removed again before
+    # the render: the reorder must still produce valid DFS order.
+    root = WorldObject()
+    g1, g2 = WorldObject(), WorldObject()
+    root.add(g1, g2)
+    tmp = WorldObject()
+    g1.add(tmp)  # dirties (g1 is not the tail)
+    g1.remove(tmp)  # remove the offending node before any render
+    assert _index_order(root) == _ref_dfs(root) == [g1, g2]
+
+    # clear() then rebuild.
+    root = WorldObject()
+    g1, g2 = WorldObject(), WorldObject()
+    root.add(g1, g2)
+    g1.add(WorldObject())
+    root.clear()
+    assert _index_order(root) == _ref_dfs(root) == []
+    c1, c2 = WorldObject(), WorldObject()
+    root.add(c1)
+    c1.add(c2)
+    assert _index_order(root) == _ref_dfs(root) == [c1, c2]
+
+
+def test_subtree_index_renderable_and_light_order_follow_dfs():
+    # renderable order is the stable tiebreak for equal sort keys, and light
+    # order maps to uniform slots; both must follow DFS pre-order after a
+    # non-tail insertion.
+    import numpy as np
+
+    def _point(name):
+        p = gfx.Points(
+            gfx.Geometry(positions=np.zeros((1, 3), "float32")),
+            gfx.PointsMaterial(),
+        )
+        p.name = name
+        return p
+
+    scene = gfx.Scene()
+    g1, g2 = gfx.Group(), gfx.Group()
+    scene.add(g1, g2)
+    p_late = _point("late")
+    g2.add(p_late)
+    p_early = _point("early")
+    g1.add(p_early)  # non-tail insert -> dirty
+    scene._ensure_subtree_index_order()
+
+    ref = _ref_dfs(scene)
+    renderable = list(scene._subtree_index.renderable)
+    # renderable is the DFS order filtered to objects-with-material.
+    assert renderable == [o for o in ref if o in scene._subtree_index.renderable]
+    assert [o.name for o in renderable] == ["early", "late"]
+
+    # Lights likewise follow DFS order.
+    scene = gfx.Scene()
+    g1, g2 = gfx.Group(), gfx.Group()
+    scene.add(g1, g2)
+    l_late = gfx.PointLight()
+    l_late.name = "late"
+    g2.add(l_late)
+    l_early = gfx.PointLight()
+    l_early.name = "early"
+    g1.add(l_early)  # non-tail -> dirty
+    scene._ensure_subtree_index_order()
+    assert [o.name for o in scene._subtree_index.lights_point] == ["early", "late"]
+
+
+def test_subtree_index_tail_append_stays_clean():
+    # The common build patterns graft at the depth-first tail, so they must
+    # NOT dirty the index (this is what keeps render a no-op walk-free path).
+    root = WorldObject()
+    for _ in range(10):
+        root.add(WorldObject())  # flat append
+    assert root._subtree_index._dfs_dirty is False
+
+    root = WorldObject()
+    for _ in range(4):
+        g = WorldObject()
+        root.add(g)
+        for _ in range(3):
+            g.add(WorldObject())  # fill each group before moving on
+    assert root._subtree_index._dfs_dirty is False
+    assert _index_order(root) == _ref_dfs(root)
+
+    root = WorldObject()  # deep rightmost spine
+    parent = root
+    for _ in range(8):
+        g = WorldObject()
+        parent.add(g)
+        parent = g
+    assert root._subtree_index._dfs_dirty is False
+
+
 def test_iter():
     class Foo(WorldObject):
         pass

--- a/tests/renderers/test_flatscene_order.py
+++ b/tests/renderers/test_flatscene_order.py
@@ -6,6 +6,7 @@ The reference here is computed independently (a from-scratch DFS + the
 renderer's sort-key formula), so it validates whatever FlatScene does
 internally. Pure CPU; no GPU/adapter needed.
 """
+
 import numpy as np
 import pylinalg as la
 import pygfx as gfx
@@ -107,10 +108,103 @@ def _scenes():
     return scenes
 
 
+def _order(scene, vm):
+    flat = FlatScene(scene, vm)
+    flat.sort()
+    return [w.wobject for w in flat._wobject_wrappers]
+
+
 def test_flatscene_renderable_order_matches_reference():
     for sname, scene in _scenes().items():
         for cname, vm in _cameras().items():
-            flat = FlatScene(scene, vm)
-            flat.sort()
-            got = [w.wobject for w in flat._wobject_wrappers]
-            assert got == _reference(scene, vm), f"{sname}/{cname}"
+            assert _order(scene, vm) == _reference(scene, vm), f"{sname}/{cname}"
+
+
+def test_flatscene_renderer_ids_assigned_and_stable():
+    # Renderer-ids (used for picking) must be unique and non-zero for every
+    # visible object, stay stable across frames, and new objects must get
+    # fresh ids — even though the per-object id pass is now cache-driven.
+    scene = gfx.Scene()
+    groups = [gfx.Group() for _ in range(3)]
+    for g in groups:
+        scene.add(g)
+    objs = [_pts() for _ in range(20)]
+    for i, o in enumerate(objs):
+        groups[i % 3].add(o)
+
+    flat = FlatScene(scene, None, 0)
+    everyone = [scene, *groups, *objs]
+    ids = [o._renderer_id for o in everyone]
+    assert all(i > 0 for i in ids)
+    assert len(set(ids)) == len(ids)
+
+    old = {o: o._renderer_id for o in everyone}
+    new = _pts()
+    scene.add(new)
+    flat2 = FlatScene(scene, None, flat.object_count)
+    assert new._renderer_id > 0
+    assert new._renderer_id not in old.values()
+    assert all(o._renderer_id == old[o] for o in everyone)
+
+    # A moved object must have its transform refreshed (uniform synced).
+    objs[0].local.x = 99.0
+    cam = gfx.PerspectiveCamera(70, 1)
+    cam.local.position = (0, 0, 10)
+    cam.show_pos((0, 0, 0))
+    FlatScene(scene, cam.view_matrix, flat2.object_count)
+    assert abs(objs[0].world.position[0] - 99.0) < 1e-6
+
+
+def test_flatscene_cache_invalidates_on_mutation():
+    # FlatScene caches camera-independent structure across frames; every
+    # mutation that changes the renderable set or sort keys must invalidate it.
+    cam = gfx.PerspectiveCamera(70, 1)
+    cam.local.position = (0, 0, 30)
+    cam.show_pos((0, 0, 0))
+    vm = cam.view_matrix
+
+    scene = gfx.Scene()
+    for i in range(12):
+        p = _pts(render_order=0)
+        p.local.position = (i - 6, 0, 0)
+        scene.add(p)
+
+    def check(msg):
+        assert _order(scene, vm) == _reference(scene, vm), msg
+
+    check("initial")
+
+    # add a renderable
+    extra = _pts(render_order=0)
+    extra.local.position = (0.5, 0, 0)
+    scene.add(extra)
+    check("after add")
+
+    # remove a renderable
+    scene.remove(scene.children[3])
+    check("after remove")
+
+    # toggle visibility
+    scene.children[2].visible = False
+    check("after hide")
+    scene.children[2].visible = True
+    check("after show")
+
+    # change render_order (reorders within the queue)
+    scene.children[5].render_order = 10
+    check("after render_order")
+
+    # change material in place (alters render_queue / alpha_method)
+    scene.children[1].material.alpha_mode = "weighted_blend"
+    check("after material alpha change")
+
+    # move an object: depth changes, positions must refresh (no epoch bump)
+    scene.children[4].local.position = (0, 0, -50)
+    check("after move")
+
+    # reparent under a group with a render_order (group_order changes)
+    g = gfx.Group()
+    g.render_order = 7
+    scene.add(g)
+    g.add(scene.children[0])
+    check("after reparent into group")

--- a/tests/renderers/test_flatscene_order.py
+++ b/tests/renderers/test_flatscene_order.py
@@ -1,0 +1,116 @@
+"""FlatScene must present renderables (and lights/shadow casters) in the same
+order the historical depth-first walk produced. This guards the incremental
+index and the vectorized depth-sort against ordering regressions.
+
+The reference here is computed independently (a from-scratch DFS + the
+renderer's sort-key formula), so it validates whatever FlatScene does
+internally. Pure CPU; no GPU/adapter needed.
+"""
+import numpy as np
+import pylinalg as la
+import pygfx as gfx
+from pygfx.renderers.wgpu.engine.renderer import FlatScene
+
+
+def _is_group(o):
+    return getattr(type(o), "_subtree_is_group", False)
+
+
+def _reference(scene, view_matrix):
+    renderables = []
+
+    def sort_key(o, group_ro):
+        m = o._material
+        rq = m.render_queue
+        sign = 1 if 1500 < rq <= 2500 else -1
+        if m.alpha_method == "weighted":
+            df = 0
+        elif view_matrix is None:
+            df = -1
+        else:
+            rel = la.vec_transform(o.world.position, view_matrix, projection=False)
+            df = float(-rel[2]) * sign
+        return (rq, group_ro, o.render_order, df)
+
+    def visit(o, group_ro):
+        if o._material is not None:
+            renderables.append((o, sort_key(o, group_ro)))
+        child_ro = o.render_order if _is_group(o) else group_ro
+        for c in o._children:
+            if c._store.visible:
+                visit(c, child_ro)
+
+    if scene._store.visible:
+        sgr = scene.render_order if _is_group(scene) else 0
+        for c in scene._children:
+            if c._store.visible:
+                visit(c, sgr)
+    renderables.sort(key=lambda t: t[1])  # stable
+    return [o for o, _ in renderables]
+
+
+def _pts(**kw):
+    p = gfx.Points(
+        gfx.Geometry(positions=np.random.rand(1, 3).astype("float32")),
+        gfx.PointsMaterial(),
+    )
+    for k, v in kw.items():
+        setattr(p, k, v)
+    return p
+
+
+def _cameras():
+    a = gfx.PerspectiveCamera(70, 1)
+    a.local.position = (3, 4, 12)
+    a.show_pos((0, 0, 0))
+    b = gfx.OrthographicCamera(10, 10)
+    b.local.position = (-2, 1, 8)
+    b.show_pos((0, 0, 0))
+    return {"none": None, "persp": a.view_matrix, "ortho": b.view_matrix}
+
+
+def _scenes():
+    rng = np.random.default_rng(1)
+    scenes = {}
+
+    s = gfx.Scene()
+    s.add(gfx.AmbientLight(), gfx.DirectionalLight())
+    for i in range(40):
+        p = _pts(render_order=i % 3)
+        p.local.position = rng.uniform(-5, 5, 3)
+        s.add(p)
+    s.children[10].visible = False
+    scenes["flat_varied"] = s
+
+    s = gfx.Scene()
+    g1, g2, g3 = gfx.Group(), gfx.Group(), gfx.Group()
+    g1.render_order, g2.render_order, g3.render_order = 5, 1, 3
+    s.add(g1, g2, g3)
+    for g in (g2, g1, g3):  # fill out of DFS-tail order
+        for _ in range(8):
+            p = _pts()
+            p.local.position = rng.uniform(-5, 5, 3)
+            g.add(p)
+    g2.visible = False
+    scenes["grouped_reordered"] = s
+
+    s = gfx.Scene()
+    s.add(gfx.AmbientLight())
+    for i in range(30):
+        p = _pts(render_order=i % 2)
+        p.local.position = rng.uniform(-5, 5, 3)
+        if i % 2 == 0:
+            p.material.alpha_mode = "weighted_blend"
+        s.add(p)
+    scenes["weighted_mix"] = s
+
+    return scenes
+
+
+def test_flatscene_renderable_order_matches_reference():
+    for sname, scene in _scenes().items():
+        for cname, vm in _cameras().items():
+            flat = FlatScene(scene, vm)
+            flat.sort()
+            got = [w.wobject for w in flat._wobject_wrappers]
+            assert got == _reference(scene, vm), f"{sname}/{cname}"


### PR DESCRIPTION
This PR makes pygfx's per-render scene-graph work incremental and then optimizes the render loop, in three commits:

1. **Maintain scene-graph index incrementally; render reads flat lists** — `FlatScene` no longer walks the tree every frame to categorize objects / propagate `group_order`.
2. **Vectorize FlatScene depth sort** — batched `vec_transform` + `np.lexsort` instead of per-object distance + Python sort.
3. **Cache camera-independent FlatScene structure across frames** — the renderable set / sort-key components / wrappers are cached on the scene; only the camera distance is recomputed per frame, positions refresh incrementally via `transform.last_modified`, and the same cache drives a single per-frame sweep that assigns renderer-ids to new objects and runs `_update_object` only for moved ones. **Invalidation is scene-scoped (a `version` counter on each object's `_subtree_index`, bumped on the object + its ancestors by render-relevant mutations; materials track their users weakly to cover in-place `render_queue`/`alpha_method` changes) — no global state.**

Render order is **bit-identical** to `main` at every commit (verified against an independent DFS+formula reference in `tests/renderers/test_flatscene_order.py`, which also covers cache invalidation and renderer-id assignment).

## Performance — progression

Per-frame `FlatScene(scene, view_matrix) + sort()` for a 3000 groups × 10 = **~33k-object** scene (median of 30 frames, GC disabled). `step` = speedup vs the previous stage; `cumulative` = vs `main`. The **cache** and **skip-id** rows below were measured as separate stages while developing; they are squashed into commit 3. Benchmark + raw data: [pygfx/pygfx-benchmarks#11](https://github.com/pygfx/pygfx-benchmarks/pull/11).

### Apple M5 Max — macOS 26.4

**Moving camera** (the realistic case — the view matrix changes every frame)

| stage | µs | step | cumulative |
|---|---:|---:|---:|
| main | 74,424 | — | 1.00× |
| 1 scene-index | 67,966 | 1.10× | 1.10× |
| 2 vectorize | 35,621 | 1.91× | 2.09× |
| 3 cache | 6,880 | 5.18× | 10.82× |
| 3 + skip-id | 4,740 | 1.45× | **15.70×** |

**No camera** (`sort_objects=False`)

| stage | µs | step | cumulative |
|---|---:|---:|---:|
| main | 35,543 | — | 1.00× |
| 1 scene-index | 25,380 | 1.40× | 1.40× |
| 2 vectorize | 26,895 | 0.94× | 1.32× |
| 3 cache | 4,055 | 6.63× | 8.77× |
| 3 + skip-id | 4,307 | 0.94× | 8.25× |

### Intel i7-1180G7 @ 1.30GHz — Ubuntu 26.04 (low-power)

**Moving camera**

| stage | µs | step | cumulative |
|---|---:|---:|---:|
| main | 439,336 | — | 1.00× |
| 1 scene-index | 388,941 | 1.13× | 1.13× |
| 2 vectorize | 210,739 | 1.85× | 2.08× |
| 3 cache | 52,549 | 4.01× | 8.36× |
| 3 + skip-id | 31,240 | 1.68× | **14.06×** |

**No camera** (`sort_objects=False`)

| stage | µs | step | cumulative |
|---|---:|---:|---:|
| main | 179,203 | — | 1.00× |
| 1 scene-index | 150,986 | 1.19× | 1.19× |
| 2 vectorize | 163,416 | 0.92× | 1.10× |
| 3 cache | 28,998 | 5.64× | 6.18× |
| 3 + skip-id | 29,749 | 0.97× | 6.02× |

### What each stage buys (consistent across both machines)

* **scene-index** — modest here (1.1–1.4×): a *flat, depth-2* grouped scene has little tree to walk; its large wins are deep hierarchies (up to ~7× in the FlatScene micro-benchmark).
* **vectorize** — ~1.9× with a moving camera (replaces 30k per-object `vec_transform` with one matmul + `lexsort`); no effect without a camera (~0.93× = noise), as expected.
* **cache** — the single biggest lever, **~4–6.6×**, helping both paths by eliminating the per-frame gather of materials/positions and wrapper allocation.
* **skip-id** — ~1.45–1.68× **only** with a moving camera (it merges the all-objects id/transform loop *and* the position refresh into one sweep — the moving path had two O(N) scans, the no-camera path only one).

**Bottom line:** `main` → tip is **~15.7× on the M5** and **~14× on nano** for a moving camera (~8× / ~6× without one). The absolute saving is largest on the weak CPU: **439 ms → 31 ms per frame** — roughly a 2 fps → 32 fps swing in the CPU portion for a 33k-object scene.

---

<details><summary>Claude's draft (commit 1 — incremental scene index)</summary>

Previously every render walked the scene graph in `FlatScene._iter_scene` to categorize objects (lights by kind, shadow casters, renderables, all objects for renderer-id assignment) and to propagate `group_order` from each Group ancestor. With deep or wide scenes this is a hot CPU path on every frame.

Now each `WorldObject` keeps a `_subtree_index` (descendant-only categorized lists) that's maintained at scene-graph mutation time: `add`/`remove`/`clear` bubble updates up the parent chain, and the `visible`, `geometry`, `material`, and `cast_shadow` setters patch the index directly. Per-object `_effective_visible` and a weakref to the closest `Group` ancestor are cached so the renderer can skip hidden subtrees and resolve `group_order` without walking. Class-level markers (`_subtree_light_kind`, `_subtree_is_group`) replace the per-frame `isinstance` checks and avoid a circular import between `_base.py` and `_lights.py`.

The index is descendant-only by design (excludes self) so subtree removal does not produce reference cycles — the existing `test_no_cyclic_references` continues to pass without `gc.collect()`. The renderer handles the scene root explicitly alongside the index contents. The categorized lists are kept in DFS pre-order (a non-tail insertion marks the index dirty and is re-sorted lazily on the next render) so renderer-id assignment and equal-key render order match the old walk.

Also loosens the screenshot-comparison atol to 4 across the board (was 1 with a per-example override) to absorb minor adapter/driver jitter without losing real regressions.
</details>

<!--
Please see the Contribution Guide:
https://github.com/pygfx/pygfx/blob/main/CONTRIBUTING.md
-->
